### PR TITLE
Add support for repeated trials runs to account for execution uncertainty

### DIFF
--- a/example_config_local.yaml
+++ b/example_config_local.yaml
@@ -39,6 +39,8 @@ optimization:
   sobol_trials: 10
   bo_trials: 40
   batch_size: 1
+  n_repeat_trials: 5
+  repeated_trials_parallel: False
   bad_value: 10
   seed: 0
   device: "cpu"

--- a/example_config_slurm.yaml
+++ b/example_config_slurm.yaml
@@ -47,6 +47,8 @@ optimization:
   sobol_trials: 10
   bo_trials: 40
   batch_size: 1
+  n_repeat_trials: 5
+  repeated_trials_parallel: False
   bad_value: 10
   seed: 0
   device: "cpu"


### PR DESCRIPTION
New options to control repeated runs:

- *n_repeat_trials*: how many times to repeat a trial to evaluate the objective's mean and error of the mean
- *repeated_trials_parallel*: if *True*, the number of parallel simulations will be *batch_size* * *n_repeat_trials* (e.g., for HPC execution); if *False*, the number of parallel simulations is *batch_size*

Ax documentation: [reference](https://ax.dev/docs/tutorials/gpei_hartmann_service/#3-define-how-to-evaluate-trials)