### PR TITLE
Add support for optimizing tolerances.

### DIFF
--- a/example_config_local.yaml
+++ b/example_config_local.yaml
@@ -78,4 +78,14 @@ optimization:
       type: "range"
       value_type: "int"
       bounds: [1, 10]
+    tolerance:
+      name: "tolerance"
+      type: "range"
+      value_type: "float"
+      bounds: [-9, -6] # log10 space
+    relTol:
+      name: "relTol"
+      type: "range"
+      value_type: "float"
+      bounds: [-3, -1] # log10 space
 

--- a/example_config_slurm.yaml
+++ b/example_config_slurm.yaml
@@ -86,4 +86,14 @@ optimization:
       type: "range"
       value_type: "int"
       bounds: [1, 10]
+    tolerance:
+      name: "tolerance"
+      type: "range"
+      value_type: "float"
+      bounds: [-9, -6] # log10 space
+    relTol:
+      name: "relTol"
+      type: "range"
+      value_type: "float"
+      bounds: [-3, -1] # log10 space
 

--- a/execution.py
+++ b/execution.py
@@ -14,6 +14,9 @@ import numpy as np
 from pandas import read_csv
 
 
+LOG10_KEYS = ("tolerance", "relTol", "toleranceCoarsest", "relTolCoarsest")
+
+
 def is_float(value: str) -> bool:
     try:
         _ = float(value)
@@ -83,7 +86,10 @@ def run_parameter_variation(
     for key in trials.keys():
         default = deepcopy(config["simulation"]["gamg"])
         for key_i, val_i in trials[key].items():
-            default[key_i] = val_i
+            if key_i in LOG10_KEYS:
+                default[key_i] = 10**val_i
+            else:
+                default[key_i] = val_i
         gamg_params[key] = default
     params_full = [sim_params | gamg_params[key] for key in gamg_params.keys()]
     params = defaultdict(list)


### PR DESCRIPTION
Ax only supports float parameters (single precision) for real-numbered parameters. When trying to optimize GAMG tolerances (*tolerance*, *relTol*), Ax raises a numerical exception for typical value ranges $O(10^{-6})$. This commit resolves the issue by converting the corresponding values to log10 space:
```
# not working
    tolerance:
      name: "tolerance"
      type: "range"
      value_type: "float"
      log_space: True
      bounds: [1e-9, 1e-6]
```
```
# new implementation
    tolerance: # in log10 space
      name: "tolerance"
      type: "range"
      value_type: "float"
      bounds: [-9, -6]
```