### PR TITLE
Fix cluster execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,14 @@ The basis of the project can be found in the repository
 
 The instructions and tests are tailored to:
 - OpenFOAM-v2406
-- Python 3.10
+- Python 3.11
 
 Newer versions might work as well but were not explicitly tested.
 
 To set up a suitable virtual environment, run:
 ```bash
 # repository top-level
-python3 -m venv bopt
+python3.11 -m venv bopt
 source bopt/bin/activate
 pip install --upgrade pip
 pip install -r requirements.txt
@@ -28,7 +28,7 @@ pip install -r requirements.txt
 
 ```
 source bopt/bin/activate
-python3 run.py example_config_local.yaml &> log.example_run
+python run.py example_config_local.yaml &> log.example_run
 ```
 
 The script *eval_runs.py* contains a rudimentary example for visualizing the outcome.
@@ -40,7 +40,7 @@ simulations multiple times with unchanged settings:
 
 ```
 source bopt/bin/activate
-python3 run_repeated.py example_config_repeated_local.yaml &> log.example_run
+python run_repeated.py example_config_repeated_local.yaml &> log.example_run
 ```
 The scripts outputs the elapsed time to a *timing_int_\*.csv* file in the experiment folder.
 
@@ -67,7 +67,7 @@ cd BayesOpt_solverSettings
 To set up a suitable virtual environment, run:
 ```bash
 # repository top-level
-module load release/24.04 GCCcore/12.2.0 Python/3.10.8
+module load release/24.04 GCCcore/12.3.0 Python/3.11.3
 python -m venv bopt
 source bopt/bin/activate
 pip install --upgrade pip
@@ -90,7 +90,7 @@ The driver script has to be started via a *jobscirpt*. A suitable jobscript look
 #SBATCH --mail-type=start,end
 #SBATCH --mail-user=<your.email>@tu-dresden.de
 
-module load release/24.04 GCCcore/12.2.0 Python/3.10.8
+module load release/24.04 GCCcore/12.3.0 Python/3.11.3
 source bopt/bin/activate
 python run.py example_config_slurm.yaml &> log.example_run
 ```

--- a/example_config_local.yaml
+++ b/example_config_local.yaml
@@ -1,7 +1,7 @@
 simulation:
   base_case: "test_cases/cylinder_2D_Re100"
   startTime: 0
-  duration: 0.1
+  duration: 1
   writeInterval: 0.5
   deltaT: 1.0e-3
   gamg:
@@ -32,20 +32,20 @@ experiment:
   launcher: "local"
 
 optimization:
-  startTime: [0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5.0, 5.5, 6.0]
+  startTime: [0, 0.5, 1.0]
   duration: 0.01
   writeInterval: 1
   deltaT: 1.0e-3
-  sobol_trials: 1
-  bo_trials: 1
+  sobol_trials: 10
+  bo_trials: 40
   batch_size: 1
-  n_repeat_trials: 5
+  n_repeat_trials: 3
   repeated_trials_parallel: False
   bad_value: 10
   seed: 0
   device: "cpu"
   stopping:
-    min_trials: 1
+    min_trials: 20
     window_size: 5
     improvement_bar: 0.01
   gamg:

--- a/example_config_slurm.yaml
+++ b/example_config_slurm.yaml
@@ -37,7 +37,7 @@ batch_settings:
     time: "00:30:00"
     ntasks: 2
     partition: "barnard"
-  preamble: ["module load release/24.04 GCC/12.3.0 OpenMPI/4.1.5 OpenFOAM/v2406", "source $FOAM_BASH"]
+  preamble: ["module load release/24.04 GCC/12.3.0 OpenMPI/4.1.5 OpenFOAM/v2406 Python/3.11.3", "source $FOAM_BASH", "source /path/to/bopt/bin/activate"]
 
 optimization:
   startTime: [0, 3.0, 5.0]

--- a/execution.py
+++ b/execution.py
@@ -71,7 +71,7 @@ def run_parameter_variation(
     exp: Experiment, trials: dict, config: dict, time_idx: int
 ) -> Dict[int, float]:
     opt_config = config["optimization"]
-    rs = RunSettings("Allrun.solve")
+    rs = RunSettings(exe="bash", exe_args="Allrun.solve")
     bs = batch_settings_from_config(exp, config.get("batch_settings"))
     path = join(exp.exp_path, "base_sim", "processor0")
     startTime = find_closest_time(path, opt_config["startTime"][time_idx])

--- a/execution.py
+++ b/execution.py
@@ -7,6 +7,7 @@ from typing import Dict, Union
 from copy import deepcopy
 from collections import defaultdict
 from math import sqrt
+from time import sleep
 from smartsim import Experiment
 from smartsim.settings import RunSettings
 from smartsim.settings.base import BatchSettings
@@ -109,14 +110,21 @@ def run_parameter_variation(
     ens.attach_generator_files(to_configure=base_case_path)
     exp.generate(ens, overwrite=True, tag="!")
     if opt_config["repeated_trials_parallel"]:
-        exp.start(ens, block=True)
+        n_parallel = opt_config["batch_size"] * opt_config["n_repeat_trials"]
+        for model_i in ens.models:
+            model_i.batch_settings = bs
+            exp.start(model_i, block=False)
+        while not all(exp.finished(model_i) for model_i in ens.models):
+            sleep(2)
     else:
         n_parallel = opt_config["batch_size"]
         for i in range(0, len(ens.models), n_parallel):
             ens_batch = ens.models[i:i+n_parallel]
             for model_i in ens_batch:
                 model_i.batch_settings = bs
-            exp.start(*ens_batch, block=True)
+                exp.start(model_i, block=False)
+            while not all(exp.finished(model_i) for model_i in ens_batch):
+                sleep(2)
     runtimes = [
         extract_runtime(
             model,

--- a/execution.py
+++ b/execution.py
@@ -8,6 +8,7 @@ from copy import deepcopy
 from collections import defaultdict
 from math import sqrt
 from smartsim import Experiment
+from smartsim.settings import RunSettings
 from smartsim.settings.base import BatchSettings
 from smartsim.entity import Model
 import numpy as np
@@ -70,7 +71,7 @@ def run_parameter_variation(
     exp: Experiment, trials: dict, config: dict, time_idx: int
 ) -> Dict[int, float]:
     opt_config = config["optimization"]
-    rs = exp.create_run_settings(exe="bash", exe_args="Allrun.solve")
+    rs = RunSettings("Allrun.solve")
     bs = batch_settings_from_config(exp, config.get("batch_settings"))
     path = join(exp.exp_path, "base_sim", "processor0")
     startTime = find_closest_time(path, opt_config["startTime"][time_idx])

--- a/run.py
+++ b/run.py
@@ -7,15 +7,15 @@ from yaml import safe_load
 from smartsim import Experiment
 from smartsim.settings import RunSettings
 from ax.service.ax_client import AxClient
-from ax.modelbridge.generation_strategy import GenerationStrategy, GenerationStep
-from ax.modelbridge.registry import Models
+from ax.generation_strategy.generation_strategy import GenerationStrategy, GenerationStep
+from ax.modelbridge.registry import Generators
 from ax.service.utils.instantiation import ObjectiveProperties
 from ax.global_stopping.strategies.improvement import ImprovementGlobalStoppingStrategy
 from ax.utils.common.logger import get_logger
 from ax.storage.json_store.save import save_experiment
 from execution import run_parameter_variation, batch_settings_from_config, LOG10_KEYS
 
-
+Generators
 # load settings
 config_file = sys.argv[1] if len(sys.argv) > 1 else "config.yaml"
 try:
@@ -58,12 +58,12 @@ for i, startTime in enumerate(opt_config["startTime"]):
     gs = GenerationStrategy(
         steps=[
             GenerationStep(
-                model=Models.SOBOL,
+                model=Generators.SOBOL,
                 num_trials=opt_config["sobol_trials"],
                 max_parallelism=opt_config["sobol_trials"],
             ),
             GenerationStep(
-                model=Models.BO_MIXED,
+                model=Generators.BO_MIXED,
                 num_trials=opt_config["bo_trials"],
                 max_parallelism=opt_config["batch_size"],
             ),

--- a/run.py
+++ b/run.py
@@ -32,7 +32,7 @@ exp = Experiment(**config["experiment"])
 sim_config = config["simulation"]
 base_case_path = sim_config["base_case"]
 base_name = base_case_path.split("/")[-1]
-rs = RunSettings("Allrun.pre")
+rs = RunSettings(exe="bash", exe_args="Allrun.pre")
 bs = batch_settings_from_config(exp, config.get("batch_settings"))
 if not isdir(join(exp.exp_path, "base_sim")):
     base_sim = exp.create_model(

--- a/run.py
+++ b/run.py
@@ -5,6 +5,7 @@ from math import log10
 from logging import INFO
 from yaml import safe_load
 from smartsim import Experiment
+from smartsim.settings import RunSettings
 from ax.service.ax_client import AxClient
 from ax.modelbridge.generation_strategy import GenerationStrategy, GenerationStep
 from ax.modelbridge.registry import Models
@@ -31,7 +32,7 @@ exp = Experiment(**config["experiment"])
 sim_config = config["simulation"]
 base_case_path = sim_config["base_case"]
 base_name = base_case_path.split("/")[-1]
-rs = exp.create_run_settings(exe="bash", exe_args="Allrun.pre")
+rs = RunSettings("Allrun.pre")
 bs = batch_settings_from_config(exp, config.get("batch_settings"))
 if not isdir(join(exp.exp_path, "base_sim")):
     base_sim = exp.create_model(


### PR DESCRIPTION
@tanujravi @JanisGeise 
there were a few issues with the cluster execution that also impacted the timing. Unfortunately, the BayesOpt experiments run so far are not reliable and have to be repeated - my apologies. I hope that the new results will be much more consistent. Also, the parallel execution should be much faster now, i.e., when setting batch_size > 1 or n_repeat_trials > 1 and repeated_trials_parallel: True.
To get the updated code running:
- update the virtual Python environment (Python 3.11 - see README)
- update the slurm config (see example_config_slurm.yaml); the path to the virtual Python environment is currently hardcoded and needs to be replaced, e.g., my path is
```
"source /data/horse/ws/workspace_name/BayesOpt_solverSettings/bopt/bin/activate"
```
- optional: replace *ntasks: 2* with *tasks-per-node: 2* in the *batch_args* (this avoid a slurm warning message)

Best, Andre